### PR TITLE
Revert and replace a refactor that lost granularity of user alerting (in some cases would result in no message)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>com.github.devotedmc</groupId>
 	<artifactId>hiddenore</artifactId>
-	<version>1.7.1</version>
+	<version>1.7.2</version>
 	<name>HiddenOre</name>
 
 	<repositories>

--- a/src/main/java/com/github/devotedmc/hiddenore/listeners/BlockBreakListener.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/listeners/BlockBreakListener.java
@@ -321,19 +321,6 @@ public class BlockBreakListener implements Listener {
 		
 	}
 
-	private void buildAlert(StringBuilder alertBuilder, ItemStack item, String nameOverride, int amount, String postfix) {
-		String name = nameOverride;
-		if (name == null && item != null) {
-			name = item.hasItemMeta() && item.getItemMeta().hasDisplayName() ? 
-					item.getItemMeta().getDisplayName() : Config.getPrettyName(item.getType().name());
-		}
-		
-		alertBuilder.append(" ").append(amount).append(" ").append(name);
-		if (postfix != null) {
-			alertBuilder.append(postfix);
-		}
-	}
-
 	private void doActualGenerate(final List<ItemStack> items, final Location sourceLocation, final Player player,
 			String dropName, String blockName, BlockConfig blockConfig, StringBuilder alertBuffer, DropConfig dropConfig) {
 		int maxWalk = 0;
@@ -386,7 +373,8 @@ public class BlockBreakListener implements Listener {
 				maxWalk --;
 			}
 
-			if (xform.getAmount() - cPlace < 1 && dropConfig.dropIfTransformFails) { // total failure.
+			int placed = xform.getAmount() - cPlace;
+			if (placed < 1 && dropConfig.dropIfTransformFails) { // total failure.
 				ItemStack toDrop = xform.clone();
 				toDrop.setAmount(Math.min(xform.getAmount(), dropConfig.maxDropsIfTransformFails));
 				final List<ItemStack> newDrops = new ArrayList<ItemStack>();
@@ -398,21 +386,21 @@ public class BlockBreakListener implements Listener {
 						
 				log("STAT: Player {0} at {1} broke {2} - replacing with {3} {4} as {6}", 
 						player.getDisplayName(), player.getLocation(), blockName, 
-						xform.getAmount()- cPlace, name, expressed);
+						placed, name, expressed);
 				
 				// Anything to tell anyone about?
-				if (cPlace < xform.getAmount() && Config.isAlertUser()) {
+				if (placed > 0 && Config.isAlertUser()) {
 					if (blockConfig.hasCustomPrefix(dropName)) {
 						// if this block has a custom prefix we alert immediately
 						StringBuilder customAlerts = new StringBuilder(blockConfig.getPrefix(dropName));
 						
-						buildAlert(customAlerts, null, name, xform.getAmount() - cPlace, " nearby");
+						buildAlert(customAlerts, null, name, placed, " nearby");
 
 						player.sendMessage(ChatColor.GOLD + customAlerts.toString());
 					} else {
 						// otherwise, we aggregate our notices and send them after all drop / gen is done.
 						if (Config.isListDrops()) {
-							buildAlert(alertBuffer, null, name, xform.getAmount() - cPlace, " nearby,");
+							buildAlert(alertBuffer, null, name, placed, " nearby,");
 						}
 					}
 				}
@@ -420,6 +408,19 @@ public class BlockBreakListener implements Listener {
 		}
 	}
 	
+	private void buildAlert(StringBuilder alertBuilder, ItemStack item, String nameOverride, int amount, String postfix) {
+		String name = nameOverride;
+		if (name == null && item != null) {
+			name = item.hasItemMeta() && item.getItemMeta().hasDisplayName() ? 
+					item.getItemMeta().getDisplayName() : Config.getPrettyName(item.getType().name());
+		}
+		
+		alertBuilder.append(" ").append(amount).append(" ").append(name);
+		if (postfix != null) {
+			alertBuilder.append(postfix);
+		}
+	}
+
 	private static BlockFace[] visibleFaces = new BlockFace[] {
 				BlockFace.DOWN, BlockFace.UP, BlockFace.EAST, BlockFace.WEST, BlockFace.NORTH, BlockFace.SOUTH
 			};


### PR DESCRIPTION
basically for generally alerting without a custom prefix, nothing will show up, so I've reverted that change and replaced it. Also with the code I've reverted, if no custom prefix, then no alerting at all. Probably an unintended side effect, but it broke user-facing reporting in the general case. This change will undo that.